### PR TITLE
Fix confidence interval helpers

### DIFF
--- a/researchpy/basic_stats.py
+++ b/researchpy/basic_stats.py
@@ -170,12 +170,10 @@ def confidence_interval(d, alpha=0.95, n=None, loc=None, scale=None, decimals=4)
 
     """
 
-    if n == None:
+    if n is None:
         n = count(d) - 1
-    if loc == None:
-        central = numpy.nanmean(d)
-    if scale == None:
-        scaler = nansem(d)
+    central = numpy.nanmean(d) if loc is None else loc
+    scaler = nansem(d) if scale is None else scale
 
     ci_intervals = list(scipy.stats.t.interval(alpha,
                                                n,
@@ -220,15 +218,13 @@ def l_ci(d, alpha=0.95, n=None, loc=None, scale=None, decimals=4):
 
     """
 
-    if n == None:
+    if n is None:
         n = count(d) - 1
-    if loc == None:
-        central = numpy.nanmean(d)
-    if scale == None:
-        scaler = nansem(d)
+    central = numpy.nanmean(d) if loc is None else loc
+    scaler = nansem(d) if scale is None else scale
 
     l_ci, _ = scipy.stats.t.interval(alpha,
-                                     n - 1,
+                                     n,
                                      loc=central,
                                      scale=scaler)
     return round(l_ci, decimals)
@@ -264,15 +260,13 @@ def u_ci(d, alpha=0.95, n=None, loc=None, scale=None, decimals=4):
 
     """
 
-    if n == None:
+    if n is None:
         n = count(d) - 1
-    if loc == None:
-        central = numpy.nanmean(d)
-    if scale == None:
-        scaler = nansem(d)
+    central = numpy.nanmean(d) if loc is None else loc
+    scaler = nansem(d) if scale is None else scale
 
     _, u_ci = scipy.stats.t.interval(alpha,
-                                     n - 1,
+                                     n,
                                      loc=central,
                                      scale=scaler)
     return round(u_ci, decimals)


### PR DESCRIPTION
## Summary
- fix `confidence_interval`, `l_ci`, and `u_ci` calculations
- add proper default fallbacks and correct degrees of freedom

## Testing
- `python3 test_researchpy.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685814d56a5c832f9d116b99a6fa9b97