### PR TITLE
Add visualization utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - **Missing Data Handling**: Robust handling of missing values across all functions
 - **Effect Size Calculations**: Comprehensive effect size measures (Cohen's d, Hedge's g, etc.)
 - **Professional Documentation**: Detailed statistical information for academic use
+- **Visualization Utilities**: High-quality plotting functions for t-tests, ANOVA, correlations, and crosstabs
 
 ## 📦 Installation
 
@@ -48,6 +49,10 @@ group2 = pd.Series(np.random.normal(12, 2, 30), name='Treatment')
 descriptives, results = rp.ttest(group1, group2)
 print(descriptives)
 print(results)
+
+# Visualize the distributions
+rp.plot_ttest(group1, group2)
+rp.plot_correlation(pd.DataFrame({'group1': group1, 'group2': group2}))
 ```
 
 ## 📚 Core Functions
@@ -240,8 +245,26 @@ T-test functions provide multiple effect size measures:
 
 ```python
 # Different effect sizes for paired t-test
-desc, results = rp.ttest(before, after, paired=True, 
+desc, results = rp.ttest(before, after, paired=True,
                          effect_size=['cohen_d', 'hedge_g'])
+```
+
+### Visualization Utilities
+
+Easily generate professional plots for common statistical tests:
+
+```python
+# T-test distribution plot
+rp.plot_ttest(group1, group2)
+
+# Correlation heatmap
+rp.plot_correlation(data[['var1', 'var2', 'var3']])
+
+# ANOVA group comparison
+rp.plot_anova("score ~ group", data=df)
+
+# Crosstab heatmap
+rp.plot_crosstab(df['group'], df['outcome'])
 ```
 
 ## 📊 Output Format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,9 @@ dependencies = [
     "numpy>=1.21.0", 
     "pandas>=1.3.0",
     "statsmodels>=0.12.0",
-    "patsy>=0.5.0"
+    "patsy>=0.5.0",
+    "matplotlib>=3.5",
+    "seaborn>=0.12"
 ]
 
 [project.optional-dependencies]

--- a/researchpy/__init__.py
+++ b/researchpy/__init__.py
@@ -25,28 +25,38 @@ from .ttest import ttest
 from .difference_test import difference_test
 
 # Summary statistics
-from .summary import (
-    summary_cont, summary_cat, codebook, summarize
-)
+from .summary import summary_cont, summary_cat, codebook, summarize
 
 # Correlation analysis
-from .correlation import (
-    corr_case, corr_pair
-)
+from .correlation import corr_case, corr_pair
 
 # Crosstabulation and chi-square
 from .crosstab import crosstab
 
+# Visualization functions
+from .visualization import (
+    plot_ttest,
+    plot_correlation,
+    plot_anova,
+    plot_crosstab,
+)
+
 # Basic statistical functions
 from .basic_stats import (
-    count, nanvar, nanstd, nansem, value_range, 
-    kurtosis, skew, confidence_interval, l_ci, u_ci
+    count,
+    nanvar,
+    nanstd,
+    nansem,
+    value_range,
+    kurtosis,
+    skew,
+    confidence_interval,
+    l_ci,
+    u_ci,
 )
 
 # Utility functions
-from .utility import (
-    variable_information, base_table
-)
+from .utility import variable_information, base_table
 
 # Advanced statistical modeling
 from .model import model
@@ -58,42 +68,64 @@ from .signrank import signrank
 
 # Model utilities and prediction
 from .predict import (
-    predict, predict_y, residuals, standardized_residuals,
-    studentized_residuals, leverage
+    predict,
+    predict_y,
+    residuals,
+    standardized_residuals,
+    studentized_residuals,
+    leverage,
 )
 
 # Define what gets imported with "from researchpy import *"
 __all__ = [
     # Metadata
-    '__version__', '__author__', '__email__', '__license__',
-    
+    "__version__",
+    "__author__",
+    "__email__",
+    "__license__",
     # Core statistical tests
-    'ttest', 'difference_test',
-    
+    "ttest",
+    "difference_test",
     # Summary statistics
-    'summary_cont', 'summary_cat', 'codebook', 'summarize',
-    
+    "summary_cont",
+    "summary_cat",
+    "codebook",
+    "summarize",
     # Correlation analysis
-    'corr_case', 'corr_pair',
-    
+    "corr_case",
+    "corr_pair",
     # Crosstabulation
-    'crosstab',
-    
+    "crosstab",
+    # Visualization functions
+    "plot_ttest",
+    "plot_correlation",
+    "plot_anova",
+    "plot_crosstab",
     # Basic statistics
-    'count', 'nanvar', 'nanstd', 'nansem', 'value_range',
-    'kurtosis', 'skew', 'confidence_interval', 'l_ci', 'u_ci',
-    
+    "count",
+    "nanvar",
+    "nanstd",
+    "nansem",
+    "value_range",
+    "kurtosis",
+    "skew",
+    "confidence_interval",
+    "l_ci",
+    "u_ci",
     # Utility functions
-    'variable_information', 'base_table',
-    
+    "variable_information",
+    "base_table",
     # Advanced modeling
-    'model', 'anova', 'ols',
-    
+    "model",
+    "anova",
+    "ols",
     # Non-parametric tests
-    'signrank',
-    
+    "signrank",
     # Model utilities
-    'predict', 'predict_y', 'residuals', 'standardized_residuals',
-    'studentized_residuals', 'leverage'
+    "predict",
+    "predict_y",
+    "residuals",
+    "standardized_residuals",
+    "studentized_residuals",
+    "leverage",
 ]
-

--- a/researchpy/correlation.py
+++ b/researchpy/correlation.py
@@ -11,108 +11,99 @@ import scipy.stats
 import itertools
 
 
+def corr_case(dataframe, method="pearson"):
 
+    df = dataframe.dropna(how="any")._get_numeric_data()
+    dfcols = pandas.DataFrame(columns=df.columns)
 
-def corr_case(dataframe, method = "pearson"):
-    
-    df = dataframe.dropna(how = 'any')._get_numeric_data()
-    dfcols = pandas.DataFrame(columns= df.columns)
-    
-    
     # Getting r an p value dataframes ready
-    r_vals = dfcols.transpose().join(dfcols, how = 'outer')
-    p_vals = dfcols.transpose().join(dfcols, how = 'outer')
+    r_vals = dfcols.transpose().join(dfcols, how="outer")
+    p_vals = dfcols.transpose().join(dfcols, how="outer")
     length = str(len(df))
-    
-    
+
     # Setting test
     if method in (None, "pearson"):
         test = scipy.stats.pearsonr
         test_name = "Pearson"
-        
+
     elif method == "spearman":
         test = scipy.stats.spearmanr
         test_name = "Spearman Rank"
-        
-    elif method == "kendall":
-        test = scipy. stats.kendalltau
-        test_name = "Kendall's Tau-b"
 
-    else:
-        raise ValueError("Unknown method: " + method)
-        
-        
-    # Rounding values for the r and p value dataframes 
-    for r in df.columns:
-        for c in df.columns:
-            r_vals.loc[r, c] = round(test(df[r], df[c])[0], 4)
-       
-    for r in df.columns:
-        for c in df.columns:
-            p_vals.loc[r, c] = format(test(df[r], df[c])[1], '.4f')
-            
-            
-    # Getting the testing information dataframe ready
-    info = pandas.DataFrame(index=range(1), 
-                         columns = [f"{test_name} correlation test using list-wise deletion"])
-    info = info.astype('object')
-    
-    info.iloc[0,0] = f"Total observations used = {length}"
-          
-    
-    
-    return info, r_vals, p_vals
-
-
-
-
-
-def corr_pair(dataframe, method= "pearson"):
-    
-    df = dataframe
-    
-    correlations = {}
-    pvalues = {}
-    length = {}
-    columns = df.columns.tolist()
-    
-    
-    # Setting test
-    if method in (None, "pearson"):
-        test = scipy.stats.pearsonr
-        test_name = "Pearson"
-        
-    elif method == "spearman":
-        test = scipy.stats.spearmanr
-        test_name = "Spearman Rank"
-        
     elif method == "kendall":
         test = scipy.stats.kendalltau
         test_name = "Kendall's Tau-b"
 
     else:
         raise ValueError("Unknown method: " + method)
-    
-    
+
+    # Rounding values for the r and p value dataframes
+    for r in df.columns:
+        for c in df.columns:
+            r_vals.loc[r, c] = round(test(df[r], df[c])[0], 4)
+
+    for r in df.columns:
+        for c in df.columns:
+            p_vals.loc[r, c] = format(test(df[r], df[c])[1], ".4f")
+
+    # Getting the testing information dataframe ready
+    info = pandas.DataFrame(
+        index=range(1),
+        columns=[f"{test_name} correlation test using list-wise deletion"],
+    )
+    info = info.astype("object")
+
+    info.iloc[0, 0] = f"Total observations used = {length}"
+
+    return info, r_vals, p_vals
+
+
+def corr_pair(dataframe, method="pearson"):
+
+    df = dataframe
+
+    correlations = {}
+    pvalues = {}
+    length = {}
+    columns = df.columns.tolist()
+
+    # Setting test
+    if method in (None, "pearson"):
+        test = scipy.stats.pearsonr
+        test_name = "Pearson"
+
+    elif method == "spearman":
+        test = scipy.stats.spearmanr
+        test_name = "Spearman Rank"
+
+    elif method == "kendall":
+        test = scipy.stats.kendalltau
+        test_name = "Kendall's Tau-b"
+
+    else:
+        raise ValueError("Unknown method: " + method)
+
     # Iterrating through the Pandas series and performing the correlation
     # analysis
     for col1, col2 in itertools.combinations(columns, 2):
-        sub = df[[col1,col2]].dropna(how= "any")
-        correlations[col1 + " " + "&" + " " + col2] = format(test(sub.loc[:, col1], sub.loc[:, col2])[0], '.4f')
-        pvalues[col1 + " " + "&" + " " + col2] = format(test(sub.loc[:, col1], sub.loc[:, col2])[1], '.4f')
-        length[col1 + " " + "&" + " " + col2] = len(df[[col1,col2]].dropna(how= "any"))
-        
-    corrs = pandas.DataFrame.from_dict(correlations, orient= "index")
-    corrs.columns = ["r value"]                
-    
-    pvals = pandas.DataFrame.from_dict(pvalues, orient= "index")
+        sub = df[[col1, col2]].dropna(how="any")
+        correlations[col1 + " " + "&" + " " + col2] = format(
+            test(sub.loc[:, col1], sub.loc[:, col2])[0], ".4f"
+        )
+        pvalues[col1 + " " + "&" + " " + col2] = format(
+            test(sub.loc[:, col1], sub.loc[:, col2])[1], ".4f"
+        )
+        length[col1 + " " + "&" + " " + col2] = len(df[[col1, col2]].dropna(how="any"))
+
+    corrs = pandas.DataFrame.from_dict(correlations, orient="index")
+    corrs.columns = ["r value"]
+
+    pvals = pandas.DataFrame.from_dict(pvalues, orient="index")
     pvals.columns = ["p-value"]
-        
-    l = pandas.DataFrame.from_dict(length, orient= "index")
+
+    l = pandas.DataFrame.from_dict(length, orient="index")
     l.columns = ["N"]
-    
-    results = corrs.join([pvals,l])
-    
+
+    results = corrs.join([pvals, l])
+
     return results
-    
-    

--- a/researchpy/visualization.py
+++ b/researchpy/visualization.py
@@ -1,0 +1,60 @@
+import matplotlib.pyplot as plt
+import seaborn as sns
+import pandas as pd
+from .ttest import ttest
+from .correlation import corr_case
+from .anova import anova
+from .crosstab import crosstab
+
+sns.set_theme(style="whitegrid", palette="muted")
+
+
+def plot_ttest(group1, group2, paired=False, equal_variances=True, palette="muted"):
+    """Visualize distributions for a t-test."""
+    _desc, _results = ttest(
+        group1,
+        group2,
+        paired=paired,
+        equal_variances=equal_variances,
+    )
+
+    data = pd.DataFrame(
+        {
+            "value": pd.concat([group1, group2]),
+            "group": [group1.name] * len(group1) + [group2.name] * len(group2),
+        }
+    )
+    plt.figure()
+    ax = sns.boxplot(x="group", y="value", data=data, palette=palette)
+    sns.stripplot(x="group", y="value", data=data, color="black", alpha=0.5, ax=ax)
+    ax.set_title("T-Test" if not paired else "Paired T-Test")
+    return ax
+
+
+def plot_correlation(dataframe, method="pearson", annot=True, cmap="coolwarm"):
+    """Plot correlation matrix heatmap."""
+    _info, r_vals, _ = corr_case(dataframe, method=method)
+    plt.figure()
+    ax = sns.heatmap(r_vals.astype(float), annot=annot, cmap=cmap, vmin=-1, vmax=1)
+    ax.set_title(f"{method.capitalize()} Correlation Matrix")
+    return ax
+
+
+def plot_anova(formula, data, palette="muted"):
+    """Visualize group means for ANOVA."""
+    analysis = anova(formula, data)
+    dv = formula.split("~")[0].strip()
+    iv = formula.split("~")[1].strip()
+    plt.figure()
+    ax = sns.boxplot(x=iv, y=dv, data=data, palette=palette)
+    ax.set_title("ANOVA")
+    return ax
+
+
+def plot_crosstab(group1, group2, palette="crest"):
+    """Plot heatmap for crosstab counts."""
+    table = crosstab(group1, group2)
+    plt.figure()
+    ax = sns.heatmap(table, annot=True, fmt="d", cmap=palette)
+    ax.set_title("Crosstabulation")
+    return ax

--- a/test_researchpy.py
+++ b/test_researchpy.py
@@ -13,59 +13,65 @@ import pandas as pd
 import numpy as np
 
 # Suppress warnings for cleaner test output
-warnings.filterwarnings('ignore', category=FutureWarning)
-warnings.filterwarnings('ignore', category=UserWarning)
+warnings.filterwarnings("ignore", category=FutureWarning)
+warnings.filterwarnings("ignore", category=UserWarning)
+
 
 def run_test_suite():
     """Run comprehensive test suite for ResearchPy."""
-    
+
     print("=" * 60)
     print("ResearchPy Comprehensive Test Suite")
     print("=" * 60)
-    
+
     # Import ResearchPy
     try:
         import researchpy as rp
+
         print(f"✓ ResearchPy imported successfully (version {rp.__version__})")
     except ImportError as e:
         print(f"✗ Failed to import ResearchPy: {e}")
         return False
-    
+
     # Set random seed for reproducibility
     np.random.seed(42)
-    
+
     # Test results storage
     test_results = []
-    
+
     # Test 1: Basic T-Test
     print("\n1. Testing T-Test Functions")
     try:
-        group1 = pd.Series(np.random.normal(10, 2, 30), name='Control')
-        group2 = pd.Series(np.random.normal(12, 2, 30), name='Treatment')
-        
+        group1 = pd.Series(np.random.normal(10, 2, 30), name="Control")
+        group2 = pd.Series(np.random.normal(12, 2, 30), name="Treatment")
+
         # Independent t-test
         desc, results = rp.ttest(group1, group2)
         assert isinstance(desc, pd.DataFrame), "Descriptives should be DataFrame"
         assert isinstance(results, pd.DataFrame), "Results should be DataFrame"
         assert desc.shape[0] == 3, "Should have 3 rows in descriptives"
         print("  ✓ Independent t-test works")
-        
+
         # Paired t-test
         desc_paired, results_paired = rp.ttest(group1, group2, paired=True)
-        assert isinstance(desc_paired, pd.DataFrame), "Paired descriptives should be DataFrame"
+        assert isinstance(
+            desc_paired, pd.DataFrame
+        ), "Paired descriptives should be DataFrame"
         print("  ✓ Paired t-test works")
-        
+
         # Welch's t-test
         desc_welch, results_welch = rp.ttest(group1, group2, equal_variances=False)
-        assert isinstance(desc_welch, pd.DataFrame), "Welch descriptives should be DataFrame"
+        assert isinstance(
+            desc_welch, pd.DataFrame
+        ), "Welch descriptives should be DataFrame"
         print("  ✓ Welch's t-test works")
-        
+
         test_results.append(("T-Test Functions", True, None))
-        
+
     except Exception as e:
         print(f"  ✗ T-Test failed: {e}")
         test_results.append(("T-Test Functions", False, str(e)))
-    
+
     # Test 2: Summary Statistics
     print("\n2. Testing Summary Statistics")
     try:
@@ -73,159 +79,176 @@ def run_test_suite():
         summary_cont = rp.summary_cont(group1)
         assert isinstance(summary_cont, pd.DataFrame), "Summary should be DataFrame"
         print("  ✓ Continuous summary works")
-        
+
         # Categorical summary
-        categories = pd.Series(['A', 'B', 'A', 'C', 'B', 'A'] * 10, name='Category')
+        categories = pd.Series(["A", "B", "A", "C", "B", "A"] * 10, name="Category")
         try:
             summary_cat = rp.summary_cat(categories)
-            assert isinstance(summary_cat, pd.DataFrame), "Categorical summary should be DataFrame"  
+            assert isinstance(
+                summary_cat, pd.DataFrame
+            ), "Categorical summary should be DataFrame"
             print("  ✓ Categorical summary works")
         except Exception as cat_error:
             print(f"  ! Categorical summary failed: {cat_error}")
-        
+
         # Codebook (function prints output but may return None)
-        test_data = pd.DataFrame({
-            'numeric': np.random.normal(0, 1, 60),
-            'categorical': categories
-        })
+        test_data = pd.DataFrame(
+            {"numeric": np.random.normal(0, 1, 60), "categorical": categories}
+        )
         try:
             codebook = rp.codebook(test_data)
             # Codebook prints output, return value may be None
             print("  ✓ Codebook works")
         except Exception as cb_error:
             print(f"  ! Codebook failed: {cb_error}")
-        
+
         test_results.append(("Summary Statistics", True, None))
-        
+
     except Exception as e:
         print(f"  ✗ Summary Statistics failed: {e}")
         test_results.append(("Summary Statistics", False, str(e)))
-    
+
     # Test 3: Correlation Analysis
     print("\n3. Testing Correlation Analysis")
     try:
-        corr_data = pd.DataFrame({
-            'x': np.random.normal(0, 1, 50),
-            'y': np.random.normal(0, 1, 50),
-            'z': np.random.normal(0, 1, 50)
-        })
-        
+        corr_data = pd.DataFrame(
+            {
+                "x": np.random.normal(0, 1, 50),
+                "y": np.random.normal(0, 1, 50),
+                "z": np.random.normal(0, 1, 50),
+            }
+        )
+
         # Case-wise correlation
         info, corr_matrix, p_values = rp.corr_case(corr_data)
-        assert isinstance(corr_matrix, pd.DataFrame), "Correlation matrix should be DataFrame"
+        assert isinstance(
+            corr_matrix, pd.DataFrame
+        ), "Correlation matrix should be DataFrame"
         assert isinstance(p_values, pd.DataFrame), "P-values should be DataFrame"
         print("  ✓ Case-wise correlation works")
-        
+
         # Pairwise correlation
         pairwise_corr = rp.corr_pair(corr_data)
-        assert isinstance(pairwise_corr, pd.DataFrame), "Pairwise correlation should be DataFrame"
+        assert isinstance(
+            pairwise_corr, pd.DataFrame
+        ), "Pairwise correlation should be DataFrame"
         print("  ✓ Pairwise correlation works")
-        
+
         test_results.append(("Correlation Analysis", True, None))
-        
+
     except Exception as e:
         print(f"  ✗ Correlation Analysis failed: {e}")
         test_results.append(("Correlation Analysis", False, str(e)))
-    
+
     # Test 4: Crosstabulation
     print("\n4. Testing Crosstabulation")
     try:
-        var1 = pd.Series(['A', 'B', 'A', 'B'] * 25)
-        var2 = pd.Series(['X', 'Y', 'X', 'Y'] * 25)
-        
+        var1 = pd.Series(["A", "B", "A", "B"] * 25)
+        var2 = pd.Series(["X", "Y", "X", "Y"] * 25)
+
         # Basic crosstab
         crosstab_result = rp.crosstab(var1, var2)
         assert isinstance(crosstab_result, pd.DataFrame), "Crosstab should be DataFrame"
         print("  ✓ Basic crosstabulation works")
-        
+
         # Crosstab with test
         try:
-            crosstab_test, chi2_results = rp.crosstab(var1, var2, test='chi-square')
+            crosstab_test, chi2_results = rp.crosstab(var1, var2, test="chi-square")
             print("  ✓ Crosstabulation with chi-square test works")
         except:
             print("  ! Chi-square test not available or failed")
-        
+
         test_results.append(("Crosstabulation", True, None))
-        
+
     except Exception as e:
         print(f"  ✗ Crosstabulation failed: {e}")
         test_results.append(("Crosstabulation", False, str(e)))
-    
+
     # Test 5: Basic Statistics Functions
     print("\n5. Testing Basic Statistics Functions")
     try:
         test_array = np.array([1, 2, np.nan, 4, 5])
-        
+
         # Count function
         count_result = rp.count(test_array)
         assert count_result == 4, f"Count should be 4, got {count_result}"
         print("  ✓ Count function works")
-        
+
         # Other basic stats
         var_result = rp.nanvar(test_array)
         std_result = rp.nanstd(test_array)
         assert not np.isnan(var_result), "Variance should not be NaN"
         assert not np.isnan(std_result), "Standard deviation should not be NaN"
         print("  ✓ Basic statistics functions work")
-        
+
         test_results.append(("Basic Statistics", True, None))
-        
+
     except Exception as e:
         print(f"  ✗ Basic Statistics failed: {e}")
         test_results.append(("Basic Statistics", False, str(e)))
-    
+
     # Test 6: Advanced Features
     print("\n6. Testing Advanced Features")
     try:
         # Test classes exist and can be instantiated
-        test_df = pd.DataFrame({
-            'dependent': np.random.normal(0, 1, 100),
-            'independent': np.random.normal(0, 1, 100)
-        })
-        
+        test_df = pd.DataFrame(
+            {
+                "dependent": np.random.normal(0, 1, 100),
+                "independent": np.random.normal(0, 1, 100),
+            }
+        )
+
         # Test difference_test class
         try:
             diff_test = rp.difference_test("dependent ~ independent", data=test_df)
-            assert hasattr(diff_test, 'conduct'), "difference_test should have conduct method"
+            assert hasattr(
+                diff_test, "conduct"
+            ), "difference_test should have conduct method"
             print("  ✓ difference_test class works")
         except Exception as diff_error:
             print(f"  ! difference_test failed: {diff_error}")
-        
+
         # Test model classes exist
-        assert hasattr(rp, 'model'), "Should have model class"
-        assert hasattr(rp, 'ols'), "Should have ols class" 
-        assert hasattr(rp, 'anova'), "Should have anova class"
+        assert hasattr(rp, "model"), "Should have model class"
+        assert hasattr(rp, "ols"), "Should have ols class"
+        assert hasattr(rp, "anova"), "Should have anova class"
         print("  ✓ Advanced model classes available")
-        
+
         test_results.append(("Advanced Features", True, None))
-        
+
     except Exception as e:
         print(f"  ✗ Advanced Features failed: {e}")
         test_results.append(("Advanced Features", False, str(e)))
-    
+
     # Test 7: Import Structure
     print("\n7. Testing Import Structure")
     try:
         # Test that all expected functions are available
         expected_functions = [
-            'ttest', 'summary_cont', 'summary_cat', 'codebook',
-            'corr_case', 'corr_pair', 'crosstab', 'count'
+            "ttest",
+            "summary_cont",
+            "summary_cat",
+            "codebook",
+            "corr_case",
+            "corr_pair",
+            "crosstab",
+            "count",
         ]
-        
+
         for func_name in expected_functions:
             assert hasattr(rp, func_name), f"Missing function: {func_name}"
-        
+
         # Test metadata
-        assert hasattr(rp, '__version__'), "Should have version"
-        assert hasattr(rp, '__author__'), "Should have author"
+        assert hasattr(rp, "__version__"), "Should have version"
+        assert hasattr(rp, "__author__"), "Should have author"
         print("  ✓ All expected functions and metadata available")
-        
+
         test_results.append(("Import Structure", True, None))
-        
+
     except Exception as e:
         print(f"  ✗ Import Structure failed: {e}")
         test_results.append(("Import Structure", False, str(e)))
-    
+
     # Test 8: Edge Cases and Error Handling
     print("\n8. Testing Edge Cases")
     try:
@@ -234,42 +257,68 @@ def run_test_suite():
         summary_with_nans = rp.summary_cont(data_with_nans)
         assert isinstance(summary_with_nans, pd.DataFrame), "Should handle NaN data"
         print("  ✓ Handles missing data correctly")
-        
+
         # Test small samples
         small_group1 = pd.Series([1, 2, 3])
         small_group2 = pd.Series([4, 5, 6])
         small_desc, small_results = rp.ttest(small_group1, small_group2)
         assert isinstance(small_desc, pd.DataFrame), "Should handle small samples"
         print("  ✓ Handles small samples correctly")
-        
+
         test_results.append(("Edge Cases", True, None))
-        
+
     except Exception as e:
         print(f"  ✗ Edge Cases failed: {e}")
         test_results.append(("Edge Cases", False, str(e)))
-    
+
+    # Test 9: Visualization Functions
+    print("\n9. Testing Visualization Functions")
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        from researchpy.visualization import (
+            plot_ttest,
+            plot_correlation,
+            plot_anova,
+            plot_crosstab,
+        )
+
+        plot_ttest(group1, group2)
+        plot_correlation(corr_data)
+        plot_anova("dependent ~ independent", test_df)
+        plot_crosstab(var1, var2)
+        plt.close("all")
+
+        test_results.append(("Visualization Functions", True, None))
+    except Exception as e:
+        print(f"  ✗ Visualization Functions failed: {e}")
+        test_results.append(("Visualization Functions", False, str(e)))
+
     # Summary Report
     print("\n" + "=" * 60)
     print("TEST SUMMARY REPORT")
     print("=" * 60)
-    
+
     passed = sum(1 for _, success, _ in test_results if success)
     total = len(test_results)
-    
+
     for test_name, success, error in test_results:
         status = "PASS" if success else "FAIL"
         print(f"{test_name:<25} {status}")
         if error:
             print(f"  Error: {error}")
-    
+
     print(f"\nResults: {passed}/{total} tests passed")
-    
+
     if passed == total:
         print("🎉 All tests passed! ResearchPy is working correctly.")
         return True
     else:
         print(f"⚠️  {total - passed} tests failed. See details above.")
         return False
+
 
 if __name__ == "__main__":
     success = run_test_suite()


### PR DESCRIPTION
## Summary
- add visualization utilities for major tests
- export visualization functions
- test new plotting options
- mention new features in README
- include matplotlib and seaborn dependencies

## Testing
- `pip install -e .`
- `python test_researchpy.py`

------
https://chatgpt.com/codex/tasks/task_e_68581c1ab968832fb87ce89476390cf4